### PR TITLE
nemotron-nano-3 : add initial support

### DIFF
--- a/models/nemotron-nano-3/README.md
+++ b/models/nemotron-nano-3/README.md
@@ -22,6 +22,7 @@ llama serve -hf __owner__/Nemotron-Nano-3-30B-A3B-GGUF
 ### TODOs
 
 - add info
+- add MTP
 
 > [!IMPORTANT]
 > This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/nemotron-nano-3/README.md
+++ b/models/nemotron-nano-3/README.md
@@ -1,0 +1,27 @@
+---
+license: other
+pipeline_tag: text-generation
+tags:
+- gguf
+- quantized
+base_model:
+- nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+---
+
+# Nemotron-Nano-3-30B-A3B
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/Nemotron-Nano-3-30B-A3B-GGUF
+```
+
+### Source models
+- https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+
+### TODOs
+
+- add info
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/nemotron-nano-3/config.sh
+++ b/models/nemotron-nano-3/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="Nemotron-Nano-3-30B-A3B"
+DEST_REPO="Nemotron-Nano-3-30B-A3B-GGUF"
+DEP_PRIMARY="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"

--- a/models/nemotron-nano-3/convert.sh
+++ b/models/nemotron-nano-3/convert.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="Nemotron-Nano-3-30B-A3B"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}.gguf" --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+"$QUANTIZE" "$OUTPUT_DIR/${DISPLAY_NAME}.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" "$OUTPUT_DIR/${DISPLAY_NAME}.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2
+
+# --- Produced files ---
+
+# Preserve the established repository name for the BF16 output.
+echo "${DISPLAY_NAME}.gguf"        >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q8_0.gguf"   >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_K_M.gguf" >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
This commit adds model conversion support for Nemotron Nano 3.

Refs: https://huggingface.co/ggml-org/Nemotron-Nano-3-30B-A3B-GGUF

----
I ran convert.py locally and it produced the following:
https://huggingface.co/danbev/Nemotron-Nano-3-30B-A3B-GGUF

I verified that the model can be run using:
```console
llama-cli -hf danbev/Nemotron-Nano-3-30B-A3B-GGUF
```