### PR TITLE
convert : add --force flag to skip SHA checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:
         description: "Model filter (regex)"
         required: false
         default: ""
+      force:
+        description: "Force re-convert (ignore SHA checks)"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   convert:
@@ -34,4 +39,8 @@ jobs:
           if [ -n "${{ github.event.inputs.filter }}" ]; then
             FILTER_ARGS="--filter ${{ github.event.inputs.filter }}"
           fi
-          bash hf-job.sh --owner ggml-org $FILTER_ARGS
+          FORCE_ARGS=""
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            FORCE_ARGS="--force"
+          fi
+          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ bash convert.sh --owner <org> --one gemma-4-12b
 # Convert models matching a filter
 bash convert.sh --owner <org> --filter '^gemma'
 
+# Force re-convert (ignore SHA checks)
+bash convert.sh --owner <org> --force
+
 # Run via HF Jobs (cloud infrastructure)
 bash hf-job.sh --owner <org>
 ```

--- a/convert.sh
+++ b/convert.sh
@@ -8,6 +8,7 @@ cd "$SCRIPT_DIR"
 OWNER=""
 ONE_MODEL=""
 FILTER_REGEX=""
+FORCE=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --owner)
@@ -21,6 +22,10 @@ while [[ $# -gt 0 ]]; do
         --filter)
             FILTER_REGEX="$2"
             shift 2
+            ;;
+        --force)
+            FORCE=true
+            shift
             ;;
         *)
             echo "Unknown argument: $1"
@@ -142,21 +147,26 @@ for config_path in "${config_paths[@]}"; do
         current_sha_lines+="${key}=${sha}"$'\n'
     done
 
-    # Read last-processed SHAs from destination repo
-    last_sha_file=$(curl -Ls "https://huggingface.co/$dest/resolve/main/.src_sha" 2>/dev/null || echo "")
+    if [ "$FORCE" = true ]; then
+        echo ">>> --force flag set: skipping SHA checks, converting anyway"
+        needs_convert=true
+    else
+        # Read last-processed SHAs from destination repo
+        last_sha_file=$(curl -Ls "https://huggingface.co/$dest/resolve/main/.src_sha" 2>/dev/null || echo "")
 
-    # Compare — re-convert if ANY dependency changed
-    needs_convert=false
-    for key in $dep_keys; do
-        current=$(echo "$current_sha_lines" | grep "^${key}=" | cut -d= -f2-)
-        last=$(echo "$last_sha_file" | grep "^${key}=" | cut -d= -f2- 2>/dev/null || echo "")
+        # Compare — re-convert if ANY dependency changed
+        needs_convert=false
+        for key in $dep_keys; do
+            current=$(echo "$current_sha_lines" | grep "^${key}=" | cut -d= -f2-)
+            last=$(echo "$last_sha_file" | grep "^${key}=" | cut -d= -f2- 2>/dev/null || echo "")
 
-        if [ "$current" != "$last" ]; then
-            echo ">>> $key changed (current: ${current:0:8}…, last: ${last:0:8}…)"
-            needs_convert=true
-            break
-        fi
-    done
+            if [ "$current" != "$last" ]; then
+                echo ">>> $key changed (current: ${current:0:8}…, last: ${last:0:8}…)"
+                needs_convert=true
+                break
+            fi
+        done
+    fi
 
     if [ "$needs_convert" = false ]; then
         echo ">>> No dependency changes detected. Uploading README only."

--- a/hf-job.sh
+++ b/hf-job.sh
@@ -24,6 +24,10 @@ while [[ $# -gt 0 ]]; do
             CONVERT_ARGS="$CONVERT_ARGS --filter $2"
             shift 2
             ;;
+        --force)
+            CONVERT_ARGS="$CONVERT_ARGS --force"
+            shift
+            ;;
         --timeout)
             TIMEOUT="$2"
             shift 2


### PR DESCRIPTION
Adds a --force flag that bypasses source model SHA comparison, forcing re-conversion regardless of whether dependencies have changed.

Changes:
- convert.sh: parse --force flag and skip SHA checks when set
- hf-job.sh: pass --force through to convert.sh
- .github/workflows/main.yml: add 'force' boolean input for workflow_dispatch
- README.md: document --force usage example

Assisted-by: llama.cpp:Qwen3.6-27B