### PR TITLE
hf-job : add --branch support for selecting repo branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,4 +43,5 @@ jobs:
           if [ "${{ github.event.inputs.force }}" = "true" ]; then
             FORCE_ARGS="--force"
           fi
-          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS
+          BRANCH_ARGS="--branch ${{ github.ref_name }}"
+          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $BRANCH_ARGS

--- a/hf-job.sh
+++ b/hf-job.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 # Hugging Face Job to run convert.sh on HF infrastructure
-# Usage: ./hf-job.sh --owner <owner> [--one <name>] [--filter <regex>] [--timeout <seconds>]
+# Usage: ./hf-job.sh --owner <owner> [--one <name>] [--filter <regex>] [--branch <name>] [--timeout <seconds>]
 
 echo ">>> Starting HF Job: Model Convert & Quantize"
 
 # Collect arguments to pass to convert.sh
 OWNER=""
+BRANCH=""
 TIMEOUT="1h"
 CONVERT_ARGS=""
 while [[ $# -gt 0 ]]; do
@@ -22,6 +23,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --filter)
             CONVERT_ARGS="$CONVERT_ARGS --filter $2"
+            shift 2
+            ;;
+        --branch)
+            BRANCH="$2"
             shift 2
             ;;
         --force)
@@ -44,6 +49,11 @@ if [ -z "$OWNER" ]; then
     exit 1
 fi
 
+CHECKOUT_CMD=""
+if [ -n "$BRANCH" ]; then
+    CHECKOUT_CMD="git checkout $BRANCH"
+fi
+
 hf jobs run \
     --namespace "$OWNER" \
     --timeout "$TIMEOUT" \
@@ -64,6 +74,8 @@ hf jobs run \
     # Clone the conversion scripts
     git clone https://github.com/ggml-org/convert.git /tmp/convert
     cd /tmp/convert
+
+    '"$CHECKOUT_CMD"'
 
     # Run the conversion script
     bash convert.sh --owner '"$OWNER"' '"$CONVERT_ARGS"'


### PR DESCRIPTION
- Use github.ref_name to pass the triggering branch to hf-job.sh
- hf-job.sh checks out the given branch after cloning inside the HF job
    
Assisted-by: llama.cpp:Qwen3.6-27B