### PR TITLE
laguna-xs-2.1 : add initial model support

### DIFF
--- a/models/laguna-xs-2.1/README.md
+++ b/models/laguna-xs-2.1/README.md
@@ -1,0 +1,23 @@
+---
+license: openmdw-1.1
+pipeline_tag: text-generation
+tags:
+- gguf
+- quantized
+base_model:
+- poolside/Laguna-XS-2.1
+---
+
+# Laguna-XS-2.1
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/Laguna-XS-2.1-GGUF
+```
+
+### Source models
+- https://huggingface.co/poolside/Laguna-XS-2.1
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/laguna-xs-2.1/config.sh
+++ b/models/laguna-xs-2.1/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="Laguna-XS-2.1"
+DEST_REPO="Laguna-XS-2.1-GGUF"
+DEP_PRIMARY="poolside/Laguna-XS-2.1"

--- a/models/laguna-xs-2.1/convert.sh
+++ b/models/laguna-xs-2.1/convert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="Laguna-XS-2.1"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+
+"$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2
+
+# --- Produced files ---
+
+echo "${DISPLAY_NAME}-BF16.gguf"   >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q8_0.gguf"   >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_K_M.gguf" >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
Adds conversion support for [poolside/Laguna-XS-2.1](https://huggingface.co/poolside/Laguna-XS-2.1) -- a 33B-A3B MoE (256 experts + 1 shared, 40 layers, 3:1 SWA/global), text-only, 256K context.

llama.cpp master already supports the architecture (`LLM_ARCH_LAGUNA`, `conversion/laguna.py`), so no special conversion flags are needed. Single dependency, no mmproj/MTP/DFlash sidecars exist for it.

Outputs: BF16, Q8_0, Q4_K_M (standard MoE `FLAGS_Q4_K_M`; the `shexp=q8_0` rule covers the shared expert).

Note: not test-converted locally -- BF16 alone needs ~66 GB of disk.