### PR TITLE
hf-job : add --hardware flag for custom compute flavor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,10 @@ on:
         required: false
         default: false
         type: boolean
+      hardware:
+        description: "HF Jobs flavor (e.g. cpu-xl, cpu-basic, gpu-small)"
+        required: false
+        default: "cpu-xl"
 
 jobs:
   convert:
@@ -44,4 +48,5 @@ jobs:
             FORCE_ARGS="--force"
           fi
           BRANCH_ARGS="--branch ${{ github.ref_name }}"
-          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $BRANCH_ARGS
+          HARDWARE_ARGS="--hardware ${{ github.event.inputs.hardware }}"
+          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $BRANCH_ARGS $HARDWARE_ARGS

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ bash convert.sh --owner <org> --force
 
 # Run via HF Jobs (cloud infrastructure)
 bash hf-job.sh --owner <org>
+
+# Run via HF Jobs with a custom hardware flavor
+bash hf-job.sh --owner <org> --hardware cpu-basic
 ```
 
 ## Notes

--- a/hf-job.sh
+++ b/hf-job.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Hugging Face Job to run convert.sh on HF infrastructure
-# Usage: ./hf-job.sh --owner <owner> [--one <name>] [--filter <regex>] [--branch <name>] [--timeout <seconds>]
+# Usage: ./hf-job.sh --owner <owner> [--one <name>] [--filter <regex>] [--branch <name>] [--timeout <seconds>] [--hardware <flavor>]
 
 echo ">>> Starting HF Job: Model Convert & Quantize"
 
@@ -10,6 +10,7 @@ echo ">>> Starting HF Job: Model Convert & Quantize"
 OWNER=""
 BRANCH=""
 TIMEOUT="1h"
+HARDWARE="cpu-xl"
 CONVERT_ARGS=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -37,7 +38,11 @@ while [[ $# -gt 0 ]]; do
             TIMEOUT="$2"
             shift 2
             ;;
-        *)
+        --hardware)
+            HARDWARE="$2"
+            shift 2
+            ;;
+        *;
             echo "Unknown argument: $1"
             exit 1
             ;;
@@ -57,7 +62,7 @@ fi
 hf jobs run \
     --namespace "$OWNER" \
     --timeout "$TIMEOUT" \
-    --flavor cpu-xl \
+    --flavor "$HARDWARE" \
     --secrets HF_TOKEN \
     --env HF_HUB_ENABLE_HF_XET=1 \
     python:3.11-slim \


### PR DESCRIPTION
## Description

Add `--hardware` CLI flag to `hf-job.sh` allowing custom HF Jobs flavors (e.g. `cpu-basic`, `gpu-small`) instead of hardcoded `cpu-xl`. Default remains `cpu-xl` for backward compatibility.

Also exposes the flag through the GitHub Actions `workflow_dispatch` inputs.

## Changes

- **hf-job.sh**: Added `--hardware` flag with default `cpu-xl`
- **.github/workflows/main.yml**: Added `hardware` workflow_dispatch input
- **README.md**: Added usage example for `--hardware`

## AI Usage Disclosure

YES. llama.cpp:Qwen3.6-27B
