### PR TITLE
convert : add --llama-commit option to pin llama.cpp version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,10 @@ on:
         description: "HF Jobs flavor"
         required: false
         default: ""
+      llama_commit:
+        description: "llama.cpp commit to checkout"
+        required: false
+        default: ""
 
 jobs:
   convert:
@@ -51,5 +55,9 @@ jobs:
           if [ -n "${{ github.event.inputs.hardware }}" ]; then
             HARDWARE_ARGS="--hardware ${{ github.event.inputs.hardware }}"
           fi
+          LLAMA_COMMIT_ARGS=""
+          if [ -n "${{ github.event.inputs.llama_commit }}" ]; then
+            LLAMA_COMMIT_ARGS="--llama-commit ${{ github.event.inputs.llama_commit }}"
+          fi
           BRANCH_ARGS="--branch ${{ github.ref_name }}"
-          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $HARDWARE_ARGS $BRANCH_ARGS
+          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $HARDWARE_ARGS $LLAMA_COMMIT_ARGS $BRANCH_ARGS

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ bash hf-job.sh --owner <org> --hardware cpu-basic
   ```
 
 - A maintainer from the [ggml-org/hf](https://github.com/orgs/ggml-org/teams/hf) team can start the workflow manually from the [Actions pane](https://github.com/ggml-org/convert/actions/workflows/main.yml)
-- The conversion uses the latest `master` of [llama.cpp](https://github.com/ggml-org/llama.cpp) by default; use `--llama-commit` to pin a specific commit
+- The conversion uses the latest `master` of [llama.cpp](https://github.com/ggml-org/llama.cpp) unless `--llama-commit` is set

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ bash convert.sh --owner <org> --filter '^gemma'
 # Force re-convert (ignore SHA checks)
 bash convert.sh --owner <org> --force
 
+# Use a specific llama.cpp commit
+bash convert.sh --owner <org> --llama-commit <commit>
+
 # Run via HF Jobs (cloud infrastructure)
 bash hf-job.sh --owner <org>
 
@@ -47,4 +50,4 @@ bash hf-job.sh --owner <org> --hardware cpu-basic
   ```
 
 - A maintainer from the [ggml-org/hf](https://github.com/orgs/ggml-org/teams/hf) team can start the workflow manually from the [Actions pane](https://github.com/ggml-org/convert/actions/workflows/main.yml)
-- The conversion uses the latest version of [llama.cpp](https://github.com/ggml-org/llama.cpp)
+- The conversion uses the latest `master` of [llama.cpp](https://github.com/ggml-org/llama.cpp) by default; use `--llama-commit` to pin a specific commit

--- a/convert.sh
+++ b/convert.sh
@@ -9,6 +9,7 @@ OWNER=""
 ONE_MODEL=""
 FILTER_REGEX=""
 FORCE=false
+LLAMA_COMMIT=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --owner)
@@ -26,6 +27,10 @@ while [[ $# -gt 0 ]]; do
         --force)
             FORCE=true
             shift
+            ;;
+        --llama-commit)
+            LLAMA_COMMIT="$2"
+            shift 2
             ;;
         *)
             echo "Unknown argument: $1"
@@ -94,10 +99,19 @@ fi
 
 echo ">>> Preparing llama.cpp"
 if [ -d "llama.cpp" ]; then
-    echo ">>> llama.cpp already exists, pulling latest master"
-    cd llama.cpp && git checkout master && git pull && cd ..
+    echo ">>> llama.cpp already exists"
+    if [ -n "$LLAMA_COMMIT" ]; then
+        cd llama.cpp && git fetch --unshallow 2>/dev/null || git fetch --all && git checkout "$LLAMA_COMMIT" && cd ..
+    else
+        cd llama.cpp && git checkout master && git pull && cd ..
+    fi
 else
-    git clone --depth 1 https://github.com/ggml-org/llama.cpp.git
+    if [ -n "$LLAMA_COMMIT" ]; then
+        git clone https://github.com/ggml-org/llama.cpp.git
+        cd llama.cpp && git checkout "$LLAMA_COMMIT" && cd ..
+    else
+        git clone --depth 1 https://github.com/ggml-org/llama.cpp.git
+    fi
 fi
 
 echo ">>> Building llama-quantize"

--- a/hf-job.sh
+++ b/hf-job.sh
@@ -42,6 +42,10 @@ while [[ $# -gt 0 ]]; do
             HARDWARE="$2"
             shift 2
             ;;
+        --llama-commit)
+            CONVERT_ARGS="$CONVERT_ARGS --llama-commit $2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1


### PR DESCRIPTION
Allows specifying a specific llama.cpp commit instead of defaulting to the latest master.

- `convert.sh`: added `--llama-commit` flag; does full clone + checkout when set
- `hf-job.sh`: passes `--llama-commit` through to convert.sh
- GHA workflow: added `llama_commit` manual dispatch input
- README: documented the new option

Usage:
```bash
bash convert.sh --owner <org> --llama-commit <commit>
bash hf-job.sh --owner <org> --llama-commit <commit>
```

**AI Usage Disclosure:** YES. llama.cpp:Qwen3.6-27B