### PR TITLE
laguna-s-2.1 : add initial model support

### DIFF
--- a/models/laguna-s-2.1/README.md
+++ b/models/laguna-s-2.1/README.md
@@ -19,5 +19,9 @@ llama serve -hf __owner__/Laguna-S-2.1-GGUF
 ### Source models
 - https://huggingface.co/poolside/Laguna-S-2.1
 
+### TODOs
+
+- add DFlash
+
 > [!IMPORTANT]
 > This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/laguna-s-2.1/README.md
+++ b/models/laguna-s-2.1/README.md
@@ -1,0 +1,23 @@
+---
+license: openmdw-1.1
+pipeline_tag: text-generation
+tags:
+- gguf
+- quantized
+base_model:
+- poolside/Laguna-S-2.1
+---
+
+# Laguna-S-2.1
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/Laguna-S-2.1-GGUF
+```
+
+### Source models
+- https://huggingface.co/poolside/Laguna-S-2.1
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/laguna-s-2.1/config.sh
+++ b/models/laguna-s-2.1/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="Laguna-S-2.1"
+DEST_REPO="Laguna-S-2.1-GGUF"
+DEP_PRIMARY="poolside/Laguna-S-2.1"

--- a/models/laguna-s-2.1/convert.sh
+++ b/models/laguna-s-2.1/convert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="Laguna-S-2.1"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+# Main model: BF16 (intermediate for quantization only -- ~235 GB, too large to publish)
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+
+"$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2
+
+# --- Produced files ---
+
+echo "${DISPLAY_NAME}-Q8_0.gguf"   >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_K_M.gguf" >> "$OUTPUT_DIR/.produced_files"

--- a/models/laguna-s-2.1/convert.sh
+++ b/models/laguna-s-2.1/convert.sh
@@ -15,7 +15,7 @@ python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
 
 # --- Quantizations ---
 
-FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type attn_=q8_0"
 
 "$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
 "$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2

--- a/models/laguna-xs-2.1/convert.sh
+++ b/models/laguna-xs-2.1/convert.sh
@@ -14,7 +14,7 @@ python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
 
 # --- Quantizations ---
 
-FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type attn_=q8_0"
 
 "$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
 "$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2


### PR DESCRIPTION
Adds conversion support for [poolside/Laguna-S-2.1](https://huggingface.co/poolside/Laguna-S-2.1), the larger sibling of the recently added `laguna-xs-2.1`.

Same `laguna` architecture, already supported by `conversion/laguna.py` upstream, so this is a straight config + convert script addition.

### Quantizations

- `Q8_0`
- `Q4_K_M` (same `--tensor-type` overrides as `laguna-xs-2.1`)

BF16 is produced as a quantization intermediate but not published -- at 117B params it is ~235 GB. This follows `gpt-oss-120b` and `deepseek-v4-flash`, which also keep BF16 unpublished.

For reference, poolside's own [Laguna-S-2.1-GGUF](https://huggingface.co/poolside/Laguna-S-2.1-GGUF) ships F16, Q8_0, Q4_K_M, an imatrix, and a DFlash draft.

### Notes

- DFlash is intentionally not included. Both poolside DFlash repos declare `architectures: ["DFlashLagunaForCausalLM"]`, which is not registered in llama.cpp's `conversion/` package -- only `DFlashDraftModel` is (in `conversion/qwen.py`). Conversion would fail. Same applies to `laguna-xs-2.1`, so DFlash for both needs upstream support first.
- This is a larger job than existing entries, though smaller than `deepseek-v4-flash` (158B), so capacity should be fine. Worth a manual run with a generous `--timeout` before it lands in the weekly schedule.
