### PR TITLE
ci : add timeout input for manual workflow runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ on:
         description: "llama.cpp commit to checkout"
         required: false
         default: ""
+      timeout:
+        description: "HF Job timeout (e.g. 2h, 30m)"
+        required: false
+        default: ""
 
 jobs:
   convert:
@@ -59,5 +63,9 @@ jobs:
           if [ -n "${{ github.event.inputs.llama_commit }}" ]; then
             LLAMA_COMMIT_ARGS="--llama-commit ${{ github.event.inputs.llama_commit }}"
           fi
+          TIMEOUT_ARGS=""
+          if [ -n "${{ github.event.inputs.timeout }}" ]; then
+            TIMEOUT_ARGS="--timeout ${{ github.event.inputs.timeout }}"
+          fi
           BRANCH_ARGS="--branch ${{ github.ref_name }}"
-          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $HARDWARE_ARGS $LLAMA_COMMIT_ARGS $BRANCH_ARGS
+          bash hf-job.sh --owner ggml-org $FILTER_ARGS $FORCE_ARGS $HARDWARE_ARGS $LLAMA_COMMIT_ARGS $TIMEOUT_ARGS $BRANCH_ARGS


### PR DESCRIPTION
## Description

Add a `timeout` input to the GitHub Actions `workflow_dispatch` so the HF Job timeout can be configured when running the workflow manually.

When left empty, `--timeout` is not passed to `hf-job.sh`, which keeps its default timeout of `1h`.

## Changes

- **.github/workflows/main.yml**: Added `timeout` workflow_dispatch input and pass it through to `hf-job.sh` when set

## AI Usage Disclosure

YES. llama.cpp:DeepSeek-4-Flash-0731