### PR TITLE
nemotron-3.5-lightning : add model conversion support

### DIFF
--- a/models/nemotron-3.5-lightning/README.md
+++ b/models/nemotron-3.5-lightning/README.md
@@ -1,0 +1,33 @@
+---
+license: other
+pipeline_tag: text-generation
+tags:
+- gguf
+- quantized
+base_model:
+- nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+---
+
+# NVIDIA-Nemotron-3.5-Lightning-30B-A3B
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF
+```
+
+### Source models
+- https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16
+
+<!--
+- https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4
+- https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash
+- https://huggingface.co/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark
+-->
+
+### TODOs
+
+- add info
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/nemotron-3.5-lightning/config.sh
+++ b/models/nemotron-3.5-lightning/config.sh
@@ -1,0 +1,7 @@
+DISPLAY_NAME="NVIDIA-Nemotron-3.5-Lightning-30B-A3B"
+DEST_REPO="NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF"
+DEP_PRIMARY="nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"
+DEP_NVFP4="nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4"
+DEP_DFLASH="nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DFlash"
+DEP_DSPARK="nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-DSpark"
+

--- a/models/nemotron-3.5-lightning/convert.sh
+++ b/models/nemotron-3.5-lightning/convert.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="NVIDIA-Nemotron-3.5-Lightning-30B-A3B"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+# Main model (no MTP layers)
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --no-mtp --model-name "$DISPLAY_NAME"
+
+# MTP layers
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-BF16.gguf" --mtp --model-name "$DISPLAY_NAME"
+
+# DFlash
+#python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_DFLASH" \
+#    --outtype bf16 --target-model "$PATH_PRIMARY" \
+#    --outfile "$OUTPUT_DIR/dflash-${DISPLAY_NAME}-NVFP4.gguf" --model-name "${DISPLAY_NAME}-DFlash"
+
+# DSpark
+#python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_DSPARK" \
+#    --target-model "$PATH_PRIMARY" \
+#    --fp8-as-q8 \
+#    --outfile "$OUTPUT_DIR/dspark-${DISPLAY_NAME}-NVFP4.gguf" --model-name "${DISPLAY_NAME}-DSpark"
+
+# NVFP4 model
+#python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_NVFP4" \
+#    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-NVFP4.gguf" --no-mtp --model-name "${DISPLAY_NAME}-NVFP4"
+
+# --- Quantizations ---
+
+FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+
+# Main model: Q8_0, Q4_K_M
+"$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2
+
+# MTP: Q8_0, Q4_0
+"$QUANTIZE"        "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" --pure "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-Q4_0.gguf" Q4_0 1>&2
+
+# --- Produced files ---
+
+# Preserve the established repository name for the BF16 output.
+echo "${DISPLAY_NAME}-BF16.gguf"        >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q8_0.gguf"        >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_K_M.gguf"      >> "$OUTPUT_DIR/.produced_files"
+#echo "${DISPLAY_NAME}-NVFP4.gguf"       >> "$OUTPUT_DIR/.produced_files"
+
+echo "mtp-${DISPLAY_NAME}-BF16.gguf"    >> "$OUTPUT_DIR/.produced_files"
+echo "mtp-${DISPLAY_NAME}-Q8_0.gguf"    >> "$OUTPUT_DIR/.produced_files"
+echo "mtp-${DISPLAY_NAME}-Q4_0.gguf"    >> "$OUTPUT_DIR/.produced_files"
+
+#echo "dflash-${DISPLAY_NAME}-NVFP4.gguf" >> "$OUTPUT_DIR/.produced_files"
+#echo "dspark-${DISPLAY_NAME}-NVFP4.gguf" >> "$OUTPUT_DIR/.produced_files"

--- a/models/nemotron-3.5-lightning/convert.sh
+++ b/models/nemotron-3.5-lightning/convert.sh
@@ -34,11 +34,17 @@ python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
 
 # --- Quantizations ---
 
-FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 --tensor-type latent=q8_0 --tensor-type attn_=q8_0 --tensor-type ssm_=q8_0"
+FLAGS_Q4_0="--pure \
+    --tensor-type token_embd.weight=q8_0 \
+    --tensor-type ^output.weight=q6_k \
+    --tensor-type shexp=q8_0 \
+    --tensor-type attn_=q8_0 \
+    --tensor-type ssm_=q8_0 \
+    "
 
-# Main model: Q8_0, Q4_K_M
+# Main model: Q8_0, Q4_0
 "$QUANTIZE"               "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
-"$QUANTIZE" $FLAGS_Q4_K_M "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_K_M.gguf" Q4_K_M 1>&2
+"$QUANTIZE" $FLAGS_Q4_0 "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_0.gguf" Q4_0 1>&2
 
 # MTP: Q8_0, Q4_0
 "$QUANTIZE"        "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/mtp-${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
@@ -49,8 +55,8 @@ FLAGS_Q4_K_M="--pure --tensor-type output.weight=q6_k --tensor-type shexp=q8_0 -
 # Preserve the established repository name for the BF16 output.
 echo "${DISPLAY_NAME}-BF16.gguf"        >> "$OUTPUT_DIR/.produced_files"
 echo "${DISPLAY_NAME}-Q8_0.gguf"        >> "$OUTPUT_DIR/.produced_files"
-echo "${DISPLAY_NAME}-Q4_K_M.gguf"      >> "$OUTPUT_DIR/.produced_files"
-#echo "${DISPLAY_NAME}-NVFP4.gguf"       >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_0.gguf"        >> "$OUTPUT_DIR/.produced_files"
+#echo "${DISPLAY_NAME}-NVFP4.gguf"      >> "$OUTPUT_DIR/.produced_files"
 
 echo "mtp-${DISPLAY_NAME}-BF16.gguf"    >> "$OUTPUT_DIR/.produced_files"
 echo "mtp-${DISPLAY_NAME}-Q8_0.gguf"    >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
This commit adds conversion support for NVIDIA Nemotron 3.5 Lightning.
It does not include NVFP4 models, including dflash and dspark.

The motivation for not including these conversion is that those
checkpoint was designed as W4A16, but the converted GGUF only says that
Its weights are NVFP4. On Blackwell, llama.cpp sees NVFP4 weights and
will automatically selects its native FP4 path, dynamically converting
activations to FP4. That makes the executed operation W4A4 which can
affect the accuracy of the draft model and therefor in turn effect the
acceptance rate of the target model. The references PR below has more
details on a solution to address this issue. Once it has been merged we
should be able to convert and publish these models, but for now we are
just commenting them out.

Refs: https://github.com/ggml-org/llama.cpp/pull/26675

-----

I've build this and uploaded to my HF account:
https://huggingface.co/danbev/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF/tree/main

I'm creating this as a draft as I want to run some manual test to try out the mtp, dflash, and dspark speculative drafting.