### PR TITLE
llama-2-7b : add model conversion support

### DIFF
--- a/models/llama-2-7b/README.md
+++ b/models/llama-2-7b/README.md
@@ -12,12 +12,6 @@ base_model:
 
 This model is used mainly for data collection for https://github.com/ggml-org/llama.cpp/discussions/4167
 
-Run with https://llama.app
-
-```bash
-llama serve -hf __owner__/Llama-2-7B-GGUF
-```
-
 ### Source models
 - https://huggingface.co/meta-llama/Llama-2-7b-hf
 

--- a/models/llama-2-7b/README.md
+++ b/models/llama-2-7b/README.md
@@ -1,0 +1,27 @@
+---
+license: llama2
+pipeline_tag: text-generation
+tags:
+- gguf
+- quantized
+base_model:
+- meta-llama/Llama-2-7b-hf
+---
+
+# Llama-2-7B
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/Llama-2-7B-GGUF
+```
+
+### Source models
+- https://huggingface.co/meta-llama/Llama-2-7b-hf
+
+### TODOs
+
+- add info
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/llama-2-7b/README.md
+++ b/models/llama-2-7b/README.md
@@ -15,9 +15,5 @@ This model is used mainly for data collection for https://github.com/ggml-org/ll
 ### Source models
 - https://huggingface.co/meta-llama/Llama-2-7b-hf
 
-### TODOs
-
-- add info
-
 > [!IMPORTANT]
 > This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/llama-2-7b/README.md
+++ b/models/llama-2-7b/README.md
@@ -10,6 +10,8 @@ base_model:
 
 # Llama-2-7B
 
+This model is used mainly for data collection for https://github.com/ggml-org/llama.cpp/discussions/4167
+
 Run with https://llama.app
 
 ```bash

--- a/models/llama-2-7b/config.sh
+++ b/models/llama-2-7b/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="Llama-2-7B"
+DEST_REPO="Llama-2-7B-GGUF"
+DEP_PRIMARY="meta-llama/Llama-2-7b-hf"

--- a/models/llama-2-7b/convert.sh
+++ b/models/llama-2-7b/convert.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="Llama-2-7B"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+"$QUANTIZE" --pure "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-F16.gguf"  F16  1>&2
+"$QUANTIZE" --pure "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+"$QUANTIZE" --pure "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q4_0.gguf" Q4_0 1>&2
+
+# --- Produced files ---
+
+echo "${DISPLAY_NAME}-BF16.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-F16.gguf"  >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q8_0.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q4_0.gguf" >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
Adds a conversion pipeline for Llama-2-7B from `meta-llama/Llama-2-7b-hf`.

- Outputs: BF16, F16, Q8_0, Q4_0
- Quantization uses only `--pure`, no other overrides
- No MTP, no MTMD

## AI usage disclosure

YES. pi:llama.cpp/Qwen3.8-27B
