### PR TITLE
qwen3.8-flash-next : add model conversion support

### DIFF
--- a/models/qwen3.8-flash-next/README.md
+++ b/models/qwen3.8-flash-next/README.md
@@ -1,0 +1,27 @@
+---
+license: other
+pipeline_tag: image-text-to-text
+tags:
+- gguf
+- quantized
+base_model:
+- Qwen/Qwen3.8-Flash-Next
+---
+
+# Qwen3.8-Flash-Next
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/Qwen3.8-Flash-Next-GGUF
+```
+
+### Source models
+- https://huggingface.co/Qwen/Qwen3.8-Flash-Next
+
+### TODOs
+
+- add info
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/qwen3.8-flash-next/config.sh
+++ b/models/qwen3.8-flash-next/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="Qwen3.8-Flash-Next"
+DEST_REPO="Qwen3.8-Flash-Next-GGUF"
+DEP_PRIMARY="Qwen/Qwen3.8-Flash-Next"

--- a/models/qwen3.8-flash-next/convert.sh
+++ b/models/qwen3.8-flash-next/convert.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+# qwen4exp is not in llama.cpp master yet, pin the PR head with --llama-commit
+# ref: https://github.com/ggml-org/llama.cpp/pull/27742
+
+DISPLAY_NAME="Qwen3.8-Flash-Next"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+# Main model (MTP is not exported for this arch): BF16 (intermediate for quantization only)
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" --no-tensor-first-split \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --model-name "$DISPLAY_NAME"
+
+# mmproj
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype q8_0 --outfile "$OUTPUT_DIR/mmproj-${DISPLAY_NAME}-Q8_0.gguf" --mmproj --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+# Main model: Q8_0, per_layer_token_embd Q4_0
+"$QUANTIZE" --keep-split --pure --tensor-type per_layer_token_embd.weight=q4_0 \
+    "$OUTPUT_DIR/${DISPLAY_NAME}-BF16-00001-of-00002.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q8_0.gguf" Q8_0 1>&2
+
+# --- Produced files ---
+
+echo "${DISPLAY_NAME}-Q8_0-00001-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q8_0-00002-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "mmproj-${DISPLAY_NAME}-Q8_0.gguf" >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
Adds pipeline support for [Qwen/Qwen3.8-Flash-Next](https://huggingface.co/Qwen/Qwen3.8-Flash-Next).

The model is `Qwen4ExpForConditionalGeneration` (HF `model_type: qwen4_exp`), a hybrid linear-attention MoE (512 experts, top-10) with PLE n-gram hash embeddings.

Produced files:

- `Qwen3.8-Flash-Next-Q8_0` (2 splits), tensor-type override: per_layer_token_embd q4_0
- `mmproj-Qwen3.8-Flash-Next-Q8_0`
- No MTP (not exported for this arch), no BF16 upload (intermediate for quantization only)

Requires qwen4exp support in llama.cpp, not in master yet: https://github.com/ggml-org/llama.cpp/pull/27742 — convert with `--llama-commit 3d7baaebb420f66a5102dee9f5e74a251f75ad95` until it merges.

## AI usage disclosure

YES. pi:llama.cpp/Qwen3.8-27B
