### PR TITLE
deepseek-v4-flash-vision-exp : add model conversion support

### DIFF
--- a/models/deepseek-v4-flash-vision-exp/README.md
+++ b/models/deepseek-v4-flash-vision-exp/README.md
@@ -1,0 +1,30 @@
+---
+license: mit
+pipeline_tag: image-text-to-text
+tags:
+- gguf
+- quantized
+base_model:
+- deepseek-ai/DeepSeek-V4-Flash-Vision-Exp
+---
+
+# DeepSeek-V4-Flash-Vision-Exp
+
+Run with https://llama.app
+
+```bash
+llama serve -hf __owner__/DeepSeek-V4-Flash-Vision-Exp-GGUF
+```
+
+### Source models
+- https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp
+
+### Notes
+- Includes a Q8_0 mmproj for the vision encoder.
+- Currently, the Q2 models do not use an imatrix calibration due to lack of one.
+
+### TODOs
+- add info
+
+> [!IMPORTANT]
+> This model is automatically converted using https://github.com/ggml-org/convert

--- a/models/deepseek-v4-flash-vision-exp/config.sh
+++ b/models/deepseek-v4-flash-vision-exp/config.sh
@@ -1,0 +1,3 @@
+DISPLAY_NAME="DeepSeek-V4-Flash-Vision-Exp"
+DEST_REPO="DeepSeek-V4-Flash-Vision-Exp-GGUF"
+DEP_PRIMARY="deepseek-ai/DeepSeek-V4-Flash-Vision-Exp"

--- a/models/deepseek-v4-flash-vision-exp/convert.sh
+++ b/models/deepseek-v4-flash-vision-exp/convert.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euox pipefail
+
+OUTPUT_DIR="$1"
+LLAMA_CPP="$2"
+
+DISPLAY_NAME="DeepSeek-V4-Flash-Vision-Exp"
+QUANTIZE="$LLAMA_CPP/build/bin/llama-quantize"
+
+# --- Conversions ---
+
+# Main model: BF16 (intermediate for quantization only)
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" --no-tensor-first-split \
+    --outtype bf16 --outfile "$OUTPUT_DIR/${DISPLAY_NAME}-BF16.gguf" --no-mtp --model-name "$DISPLAY_NAME"
+
+# DSpark sidecar: BF16
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/dspark-${DISPLAY_NAME}-BF16.gguf" --dspark --target-model-dir "$PATH_PRIMARY" --model-name "$DISPLAY_NAME"
+
+# mmproj: BF16
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype bf16 --outfile "$OUTPUT_DIR/mmproj-${DISPLAY_NAME}-BF16.gguf" --mmproj --model-name "$DISPLAY_NAME"
+
+# --- Quantizations ---
+
+FLAGS_MXFP4="\
+"
+
+# Main model: MXFP4_MOE
+"$QUANTIZE" --keep-split $FLAGS_MXFP4 "$OUTPUT_DIR/${DISPLAY_NAME}-BF16-00001-of-00002.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-MXFP4.gguf" MXFP4_MOE 1>&2
+
+FLAGS_Q2_K="--pure \
+    --tensor-type token_embd.weight=q8_0 \
+    --tensor-type output.weight=q6_k \
+    --tensor-type attn_=q8_0 \
+    --tensor-type shexp=q8_0 \
+    --tensor-type hc_attn=q8_0 \
+    --tensor-type hc_ffn=q8_0 \
+    --tensor-type indexer=q8_0 \
+    --tensor-type output_hc=q8_0 \
+    --tensor-type ffn_down_exps=mxfp4 \
+    --tensor-type ffn_gate_exps=q2_k \
+    --tensor-type ffn_up_exps=q2_k \
+"
+
+# Main model: MXFP4_MOE + Q2_K overrides
+"$QUANTIZE" --keep-split --allow-requantize $FLAGS_Q2_K "$OUTPUT_DIR/${DISPLAY_NAME}-BF16-00001-of-00002.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q2_K.gguf" MXFP4_MOE 1>&2
+
+FLAGS_Q2_K_S="--pure \
+    --tensor-type token_embd.weight=q8_0 \
+    --tensor-type output.weight=q6_k \
+    --tensor-type attn_=q8_0 \
+    --tensor-type shexp=q8_0 \
+    --tensor-type hc_attn=q8_0 \
+    --tensor-type hc_ffn=q8_0 \
+    --tensor-type indexer=q8_0 \
+    --tensor-type output_hc=q8_0 \
+    --tensor-type ffn_down_exps=q2_k \
+    --tensor-type ffn_gate_exps=q2_k \
+    --tensor-type ffn_up_exps=q2_k \
+"
+
+# Main model: MXFP4_MOE + Q2_K_S overrides
+"$QUANTIZE" --keep-split --allow-requantize $FLAGS_Q2_K_S "$OUTPUT_DIR/${DISPLAY_NAME}-BF16-00001-of-00002.gguf" "$OUTPUT_DIR/${DISPLAY_NAME}-Q2_K_S.gguf" MXFP4_MOE 1>&2
+
+FLAGS_MXFP4="\
+"
+
+# DSpark sidecar: MXFP4
+"$QUANTIZE" $FLAGS_MXFP4 "$OUTPUT_DIR/dspark-${DISPLAY_NAME}-BF16.gguf" "$OUTPUT_DIR/dspark-${DISPLAY_NAME}-MXFP4.gguf" MXFP4_MOE 1>&2
+
+# mmproj: Q8_0
+python3 "$LLAMA_CPP/convert_hf_to_gguf.py" "$PATH_PRIMARY" \
+    --outtype q8_0 --outfile "$OUTPUT_DIR/mmproj-${DISPLAY_NAME}-Q8_0.gguf" --mmproj --model-name "$DISPLAY_NAME"
+
+# --- Produced files ---
+
+echo "${DISPLAY_NAME}-MXFP4-00001-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-MXFP4-00002-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q2_K-00001-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q2_K-00002-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q2_K_S-00001-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "${DISPLAY_NAME}-Q2_K_S-00002-of-00002.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "dspark-${DISPLAY_NAME}-BF16.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "dspark-${DISPLAY_NAME}-MXFP4.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "mmproj-${DISPLAY_NAME}-BF16.gguf" >> "$OUTPUT_DIR/.produced_files"
+echo "mmproj-${DISPLAY_NAME}-Q8_0.gguf" >> "$OUTPUT_DIR/.produced_files"


### PR DESCRIPTION
Adds a conversion pipeline for DeepSeek-V4-Flash-Vision-Exp from `deepseek-ai/DeepSeek-V4-Flash-Vision-Exp`.

- Vision model: includes a Q8_0 mmproj for the vision encoder
- Main model outputs: MXFP4, Q2_K, Q2_K_S
- DSPark sidecar: MXFP4
- No imatrix calibration for the Q2 models

## AI usage disclosure

YES. pi:llama.cpp/DeepSeek-v4-Flash-0731